### PR TITLE
Updating selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,2 @@
-## 0.1.0 - First Release
-* Every feature added
-* Every bug fixed
+## 0.1.5
+* Forked from https://github.com/ignism/monday-syntax

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015 <Your name here>
+Copyright (c) 2015 Mark Brand
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# monday-syntax theme
+# montag-syntax theme
 
-A fresh and dark syntax theme.
+A fresh and dark syntax theme forked from Ignism's Monday syntax theme.
 
 ####JavaScript
 ![screenshot js](http://i.imgur.com/F6p82w5.png)

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "monday-syntax",
+  "name": "montag-syntax",
   "theme": "syntax",
-  "version": "0.1.4",
-  "description": "A fresh and dark syntax theme.",
+  "version": "0.1.5",
+  "description": "A fresh and dark syntax theme forked from Ignism's Monday syntax theme.",
   "keywords": [
     "syntax",
     "theme"
   ],
-  "repository": "https://github.com/ignism/monday-syntax",
+  "repository": "https://github.com/evnpwr/monday-syntax",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.174.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "montag-syntax",
   "theme": "syntax",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A fresh and dark syntax theme forked from Ignism's Monday syntax theme.",
   "keywords": [
     "syntax",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "montag-syntax",
   "theme": "syntax",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "A fresh and dark syntax theme forked from Ignism's Monday syntax theme.",
   "keywords": [
     "syntax",

--- a/styles/base.less
+++ b/styles/base.less
@@ -40,7 +40,7 @@ atom-text-editor .search-results .syntax--marker.current-result .region,atom-tex
   border: @syntax-result-marker-color-selected;
 }
 
-atom-text-editor.is-focused .selection .region,atom-text-editor .selection .region {
+atom-text-editor.is-focused .cursor,atom-text-editor .cursor {
   border-color: @syntax-cursor-color;
 }
 
@@ -201,11 +201,11 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: @light-yellow;
 }
 
-.syntax--storage.syntax--type.primitive.array.syntax--java {
+.syntax--storage.syntax--type.syntax--primitive.syntax--array.syntax--java {
   color: @light-blue;
 }
 
-.syntax--storage.syntax--type.object.array.syntax--java {
+.syntax--storage.syntax--type.syntax--object.syntax--array.syntax--java {
   color: @light-blue;
 }
 
@@ -217,7 +217,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: @blue;
 }
 
-.syntax--keyword.operator.dereference.syntax--java {
+.syntax--keyword.syntax--operator.syntax--dereference.syntax--java {
   color: @green;
 }
 

--- a/styles/base.less
+++ b/styles/base.less
@@ -100,8 +100,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: @light-yellow;
 }
 
-.syntax--entity.syntax--name.syntax--function
- {
+.syntax--entity.syntax--name.syntax--function {
   color: @pink;
 }
 
@@ -110,51 +109,35 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: @light-purple;
 }
 
-.syntax--entity.syntax--name.syntax--tag
-
- {
+.syntax--entity.syntax--name.syntax--tag {
   color: @yellow;
 }
 
-.syntax--entity.syntax--other.syntax--attribute-name
-
- {
+.syntax--entity.syntax--other.syntax--attribute-name {
   color: @blue;
 }
 
-.syntax--support.syntax--function
-
- {
+.syntax--support.syntax--function {
   color: @light-blue;
 }
 
-.syntax--support.syntax--constant
-
- {
+.syntax--support.syntax--constant {
   color: @purple;
 }
 
-.syntax--support.syntax--type, .syntax--support.syntax--class
-
- {
+.syntax--support.syntax--type, .syntax--support.syntax--class {
   color: @light-yellow;
 }
 
-.syntax--support.syntax--other.syntax--variable
-
- {
+.syntax--support.syntax--other.syntax--variable {
   color: @light-purple;
 }
 
-.syntax--source.syntax--ruby
-
- {
+.syntax--source.syntax--ruby {
   color: rgba(197, 200, 198, 1);
 }
 
-.syntax--constant.syntax--other.syntax--symbol.syntax--ruby.19syntax
-
- {
+.syntax--constant.syntax--other.syntax--symbol.syntax--ruby.19syntax {
   color: rgba(153, 204, 153, 1);
 }
 
@@ -162,27 +145,19 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: rgba(198, 197, 226, 1);
 }
 
-.syntax--entity.syntax--name.syntax--type.syntax--class.syntax--ruby
-
- {
+.syntax--entity.syntax--name.syntax--type.syntax--class.syntax--ruby {
   color: @light-yellow;
 }
 
-.syntax--entity.syntax--name.syntax--type.syntax--module.syntax--ruby
-
- {
+.syntax--entity.syntax--name.syntax--type.syntax--module.syntax--ruby {
   color: @light-yellow;
 }
 
-.syntax--source.syntax--ruby
-
-.syntax--embedded.syntax--source {
+.syntax--source.syntax--ruby.syntax--embedded.syntax--source {
   color: rgba(237, 237, 237, 1);
 }
 
-.syntax--source.syntax--ruby
-
-.syntax--embedded.syntax--source .syntax--punctuation.syntax--section.syntax--embedded.syntax--ruby {
+.syntax--source.syntax--ruby.syntax--embedded.syntax--source .syntax--punctuation.syntax--section.syntax--embedded.syntax--ruby {
   color: @blue;
 }
 
@@ -194,9 +169,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: @light-pink;
 }
 
-.syntax--entity.syntax--name.syntax--type.syntax--class.syntax--java
-
- {
+.syntax--entity.syntax--name.syntax--type.syntax--class.syntax--java {
   text-decoration: underline;
   color: @light-yellow;
 }
@@ -221,14 +194,10 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: @green;
 }
 
-.syntax--markup.syntax--inserted.syntax--diff, .syntax--meta.syntax--diff.syntax--header.syntax--to-file
-
- {
+.syntax--markup.syntax--inserted.syntax--diff, .syntax--meta.syntax--diff.syntax--header.syntax--to-file {
   color: @green;
 }
 
-.syntax--markup.syntax--deleted.syntax--diff, .syntax--meta.syntax--diff.syntax--header.syntax--from-file
-
- {
+.syntax--markup.syntax--deleted.syntax--diff, .syntax--meta.syntax--diff.syntax--header.syntax--from-file {
   color: @pink;
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,203 +1,234 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor,atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-atom-text-editor .gutter, :host .gutter {
+atom-text-editor .gutter,atom-text-editor .gutter {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
 }
 
-atom-text-editor .gutter .line-number.cursor-line, :host .gutter .line-number.cursor-line {
+atom-text-editor .gutter .line-number.cursor-line,atom-text-editor .gutter .line-number.cursor-line {
   background-color: @syntax-gutter-background-color-selected;
   color: @syntax-gutter-text-color-selected;
 }
 
-atom-text-editor .gutter .line-number.cursor-line-no-selection, :host .gutter .line-number.cursor-line-no-selection {
+atom-text-editor .gutter .line-number.cursor-line-no-selection,atom-text-editor .gutter .line-number.cursor-line-no-selection {
   color: @syntax-gutter-text-color-selected;
 }
 
-atom-text-editor .wrap-guide, :host .wrap-guide {
+atom-text-editor .wrap-guide,atom-text-editor .wrap-guide {
   color: @syntax-wrap-guide-color;
 }
 
-atom-text-editor .indent-guide, :host .indent-guide {
+atom-text-editor .indent-guide,atom-text-editor .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-atom-text-editor .invisible-character, :host .invisible-character {
+atom-text-editor .invisible-character,atom-text-editor .invisible-character {
   color: @syntax-invisible-character-color;
 }
 
-atom-text-editor .search-results .marker .region, :host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region,atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region, :host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region,atom-text-editor .search-results .syntax--marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
-atom-text-editor.is-focused .cursor, :host(.is-focused) .cursor {
+atom-text-editor.is-focused .selection .region,atom-text-editor .selection .region {
   border-color: @syntax-cursor-color;
 }
 
-atom-text-editor.is-focused .selection .region, :host(.is-focused) .selection .region {
+atom-text-editor.is-focused .selection .region,atom-text-editor .selection .region {
   background-color: @syntax-selection-color;
 }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,atom-text-editor .line-number.cursor-line-no-selection,atom-text-editor .line.cursor-line {
   background-color: @syntax-selection-color;
 }
 
-.comment {
+.syntax--comment {
   color: @gray;
 }
 
-.string {
+.syntax--string {
   color: @light-green;
 }
 
-.constant.numeric {
+.syntax--constant.syntax--numeric {
   color: @green;
 }
 
-.constant.language {
+.syntax--constant.syntax--language {
   color: @purple;
 }
 
-.constant.character, .constant.other {
+.syntax--constant.syntax--character, .syntax--constant.syntax--other {
   color: @purple;
 }
 
-.variable {
+.syntax--variable {
   color: @light-purple;
 }
 
-.keyword {
+.syntax--keyword {
   color: @yellow;
 }
 
-.storage {
+.syntax--storage {
   color: @light-blue;
 }
 
-.storage.type {
+.syntax--storage.syntax--type {
   font-style: italic;
   color: @blue;
 }
 
-.entity.name.class {
+.syntax--entity.syntax--name.syntax--class {
   text-decoration: underline;
   color: @light-yellow;
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   font-style: italic;
   text-decoration: underline;
   color: @light-yellow;
 }
 
-.entity.name.function {
+.syntax--entity.syntax--name.syntax--function
+ {
   color: @pink;
 }
 
-.variable.parameter {
+.syntax--variable.syntax--parameter {
   font-style: italic;
   color: @light-purple;
 }
 
-.entity.name.tag {
+.syntax--entity.syntax--name.syntax--tag
+
+ {
   color: @yellow;
 }
 
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name
+
+ {
   color: @blue;
 }
 
-.support.function {
+.syntax--support.syntax--function
+
+ {
   color: @light-blue;
 }
 
-.support.constant {
+.syntax--support.syntax--constant
+
+ {
   color: @purple;
 }
 
-.support.type, .support.class {
+.syntax--support.syntax--type, .syntax--support.syntax--class
+
+ {
   color: @light-yellow;
 }
 
-.support.other.variable {
+.syntax--support.syntax--other.syntax--variable
+
+ {
   color: @light-purple;
 }
 
-.source.ruby {
+.syntax--source.syntax--ruby
+
+ {
   color: rgba(197, 200, 198, 1);
 }
 
-.constant.other.symbol.ruby.19syntax {
+.syntax--constant.syntax--other.syntax--symbol.syntax--ruby.19syntax
+
+ {
   color: rgba(153, 204, 153, 1);
 }
 
-.variable.other.constant.ruby {
+.syntax--variable.syntax--other.syntax--constant.syntax--ruby {
   color: rgba(198, 197, 226, 1);
 }
 
-.entity.name.type.class.ruby {
+.syntax--entity.syntax--name.syntax--type.syntax--class.syntax--ruby
+
+ {
   color: @light-yellow;
 }
 
-.entity.name.type.module.ruby {
+.syntax--entity.syntax--name.syntax--type.syntax--module.syntax--ruby
+
+ {
   color: @light-yellow;
 }
 
-.source.ruby.embedded.source {
+.syntax--source.syntax--ruby
+
+.syntax--embedded.syntax--source {
   color: rgba(237, 237, 237, 1);
 }
 
-.source.ruby.embedded.source .punctuation.section.embedded.ruby {
+.syntax--source.syntax--ruby
+
+.syntax--embedded.syntax--source .syntax--punctuation.syntax--section.syntax--embedded.syntax--ruby {
   color: @blue;
 }
 
-.storage.modifier.import.java {
+.syntax--storage.syntax--modifier.syntax--import.syntax--java {
   color: @light-blue;
 }
 
-.storage.modifier.java {
+.syntax--storage.syntax--modifier.syntax--java {
   color: @light-pink;
 }
 
-.entity.name.type.class.java {
+.syntax--entity.syntax--name.syntax--type.syntax--class.syntax--java
+
+ {
   text-decoration: underline;
   color: @light-yellow;
 }
 
-.storage.type.primitive.array.java {
+.syntax--storage.syntax--type.primitive.array.syntax--java {
   color: @light-blue;
 }
 
-.storage.type.object.array.java {
+.syntax--storage.syntax--type.object.array.syntax--java {
   color: @light-blue;
 }
 
-.constant.numeric.java {
+.syntax--constant.syntax--numeric.syntax--java {
   color: @green;
 }
 
-.storage.type.java {
+.syntax--storage.syntax--type.syntax--java {
   color: @blue;
 }
 
-.keyword.operator.dereference.java {
+.syntax--keyword.operator.dereference.syntax--java {
   color: @green;
 }
 
-.markup.inserted.diff, .meta.diff.header.to-file {
+.syntax--markup.syntax--inserted.syntax--diff, .syntax--meta.syntax--diff.syntax--header.syntax--to-file
+
+ {
   color: @green;
 }
 
-.markup.deleted.diff, .meta.diff.header.from-file {
+.syntax--markup.syntax--deleted.syntax--diff, .syntax--meta.syntax--diff.syntax--header.syntax--from-file
+
+ {
   color: @pink;
 }


### PR DESCRIPTION
Hi,
I updated the selectors in this theme. 
Here's the message from the Deprecation Cop:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. 